### PR TITLE
Relax version bounds on core and lazy dependencies

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "Lazy.List"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v <= 4.0.0",
-        "elm-lang/lazy": "1.0.0 <= v <= 1.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/lazy": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
Fixes https://github.com/elm-community/elm-lazy-list/issues/2

Pinning them to core@4.0.0 and lazy@1.0.0 was presumably not intended.